### PR TITLE
Read refactor

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,6 +18,12 @@ libraryDependencies ++= Seq(
   "org.apache.curator"         % "curator-x-discovery"     % "2.8.0"
 )
 
+// Test dependencies
+
+libraryDependencies ++= Seq(
+  "org.mockito"               % "mockito-core"             %"1.10.19" % "test"
+)
+
 val TestOptionNoTraces = "-oD"
 val TestOptionShortTraces = "-oDS"
 val TestOptionFullTraces = "-oDF"

--- a/src/main/scala/com.socrata.snapshotter/GZipCompressInputStream.scala
+++ b/src/main/scala/com.socrata.snapshotter/GZipCompressInputStream.scala
@@ -57,30 +57,9 @@ class GZipCompressInputStream(val underlying: InputStream, pipeBufferSize: Int) 
     }
 
     def read(bytes: Array[Byte], baseOff: Int, len: Int): Int = {
-
-      def loop(bytes: Array[Byte], loopOffest: Int, len: Int): Int = {
-        logger.debug("Loop called inside read, byte array length: {}", bytes.length)
-        logger.debug("offset: {}, length limit: {}", loopOffest, len)
-        val bytesRead = compressed.read(bytes, loopOffest, len)
-        val newOffset = loopOffest + bytesRead
-        val newLen = len - bytesRead
-        val delta = if (bytesRead != ReadFinished && newLen != 0) loop(bytes, newOffset, newLen) else 0
-        if (bytesRead > 0) bytesRead + delta else delta
-      }
-
-      logger.debug("Read called, byte array length: {}", bytes.length)
-      logger.debug("offset: {}, length limit: {}", baseOff, len)
-      val bytesRead = compressed.read(bytes, baseOff, len)
-
-      if (bytesRead == ReadFinished) {
-        ReadFinished
-      } else {
-        val offset = baseOff + bytesRead
-        val newLen = len - bytesRead
-        val loopTotal = if (bytesRead != ReadFinished && newLen != 0) loop(bytes, offset, newLen) else 0
-        logger.debug("Returning gzip read with loopTotal: {} and bytesRead: {}", loopTotal, bytesRead)
-        loopTotal + bytesRead
-      }
+      val res = compressed.read(bytes, baseOff, len)
+      if (res == ReadFinished && pendingException.isDefined) throw pendingException.get
+      res
     }
 
     def shutdown(): Unit = {

--- a/src/main/scala/com.socrata.snapshotter/SnapshotService.scala
+++ b/src/main/scala/com.socrata.snapshotter/SnapshotService.scala
@@ -1,6 +1,6 @@
 package com.socrata.snapshotter
 
-import java.io.{FileOutputStream, InputStream}
+import java.io.{ByteArrayInputStream, FileOutputStream, InputStream}
 import java.nio.file.{StandardCopyOption, Files, Paths}
 
 import com.amazonaws.services.s3.model._
@@ -55,7 +55,7 @@ case class SnapshotService(client: CuratedServiceClient) extends SimpleResource 
 
 //      val zipped = new GZipCompressInputStream(resp.inputStream(), gzipBufferSize)
 //      val chunked = new StreamChunker(zipped, gzipBufferSize)
-//      val tempFile = new FileOutputStream("/tmp/chunked.csv", false)
+//      val tempFile = new FileOutputStream("/tmp/chunked.csv.gz", false)
 //      chunked.foreach { case (chunk, _) => IOUtils.copy(chunk, tempFile) }
 //      Left(JString("Saved a file!"))
 

--- a/src/main/scala/com.socrata.snapshotter/SnapshotService.scala
+++ b/src/main/scala/com.socrata.snapshotter/SnapshotService.scala
@@ -53,6 +53,7 @@ case class SnapshotService(client: CuratedServiceClient) extends SimpleResource 
     if (resp.resultCode == 200) {
       val now = new DateTime(DateTimeZone.forID("UTC"))
 
+//      Debug by downloading a file locally
 //      val zipped = new GZipCompressInputStream(resp.inputStream(), gzipBufferSize)
 //      val chunked = new StreamChunker(zipped, gzipBufferSize)
 //      val tempFile = new FileOutputStream("/tmp/chunked.csv.gz", false)

--- a/src/main/scala/com.socrata.snapshotter/StreamChunker.scala
+++ b/src/main/scala/com.socrata.snapshotter/StreamChunker.scala
@@ -29,7 +29,7 @@ class StreamChunker(inStream: InputStream, bufferSize: Int) extends Iterator[(By
     val returnSize = chunkSize.get
     logger.debug("Returning next chunk stream, size: {}", returnSize)
     logger.debug("This chunk is greater than 5 MB: {}", returnSize > (5 * 1024 * 1024))
-    val chunkStream = new ByteArrayInputStream(buffer, 0, chunkSize.get)
+    val chunkStream = new ByteArrayInputStream(buffer.slice(0, chunkSize.get))
     chunkSize = None
     (chunkStream, returnSize)
   }
@@ -57,7 +57,7 @@ class StreamChunker(inStream: InputStream, bufferSize: Int) extends Iterator[(By
     logger.debug("readToCapacity called, byte array length: {}", buffer.length)
     val bytesRead = input.read(buffer)
 
-    // if the very first read attempt returns -1, we return -1. otherwise we need to return the bytesRead
+    // if the very first read attempt returns -1, we return None. Otherwise we need to return the bytesRead
     if (bytesRead == ReadFinished) {
       logger.debug("Returning readToCapacity with -1, finished reading input stream")
       None

--- a/src/main/scala/com.socrata.snapshotter/StreamChunker.scala
+++ b/src/main/scala/com.socrata.snapshotter/StreamChunker.scala
@@ -7,16 +7,17 @@ import org.slf4j.LoggerFactory
 import StreamChunker._
 
 class StreamChunker(inStream: InputStream, bufferSize: Int) extends Iterator[(ByteArrayInputStream, Int)] {
+
+  private val ReadFinished = -1
+  private val logger = LoggerFactory.getLogger(getClass)
   private var chunkSize: Option[Int] = None
   val buffer = new Array[Byte](bufferSize)
-  private val logger = LoggerFactory.getLogger(getClass)
 
   def hasNext: Boolean = {
     // if the last thing has been read out
     if (chunkSize.isEmpty) {
-      val sizeRead = inStream.read(buffer)
-      logger.debug("Claiming to have read {} bytes of data into the buffer", sizeRead)
-      chunkSize = if (sizeRead != -1) Some(sizeRead) else None
+      val sizeRead = readToCapacity(inStream, buffer)
+      chunkSize = if (sizeRead != ReadFinished) Some(sizeRead) else None
     }
     // for sure hasNext, because the chunk is there & waiting
     chunkSize.isDefined
@@ -34,6 +35,7 @@ class StreamChunker(inStream: InputStream, bufferSize: Int) extends Iterator[(By
     (chunkStream, returnSize)
   }
 
+  /** Get an iterator of nicely packaged chunk objects, each containing: inputStream, streamSize, and partNumber */
   def chunks: Iterator[Chunk] = {
     this.zipWithIndex.map { case ((stream, streamSize), index) =>
       logger.debug("Creating chunk#{} with size of {}", index + 1, streamSize)
@@ -41,6 +43,32 @@ class StreamChunker(inStream: InputStream, bufferSize: Int) extends Iterator[(By
     }
   }
 
+  // Read from the input stream until the buffer is completely filled (or stream is finished)
+  private def readToCapacity(input: InputStream, buffer: Array[Byte]): Int = {
+
+    def loop(bytes: Array[Byte], loopOffest: Int, len: Int): Int = {
+      logger.debug("Looping inside read with offset: {}, length limit: {}", loopOffest, len)
+      val bytesRead = input.read(bytes, loopOffest, len)
+      val newOffset = loopOffest + bytesRead
+      val newLen = len - bytesRead
+      val delta = if (bytesRead != ReadFinished && newLen != 0) loop(bytes, newOffset, newLen) else 0
+      if (bytesRead > 0) bytesRead + delta else delta
+    }
+
+    logger.debug("readToCapacity called, byte array length: {}", buffer.length)
+    val bytesRead = input.read(buffer)
+
+    // if the very first read attempt returns -1, we return -1. otherwise we need to return the bytesRead
+    if (bytesRead == ReadFinished) {
+      logger.debug("Returning readToCapacity with -1, finished reading input stream")
+      ReadFinished
+    } else {
+      val newLen = buffer.length - bytesRead
+      val loopTotal = if (bytesRead != ReadFinished && newLen != 0) loop(buffer, bytesRead, newLen) else 0
+      logger.debug("Returning readToCapacity with total read: {}", loopTotal + bytesRead)
+      loopTotal + bytesRead
+    }
+  }
 }
 
 object StreamChunker {

--- a/src/test/scala/com/socrata/snapshotter/StreamChunkerTest.scala
+++ b/src/test/scala/com/socrata/snapshotter/StreamChunkerTest.scala
@@ -5,60 +5,70 @@ import java.io.{ByteArrayOutputStream, ByteArrayInputStream}
 import org.scalatest.mock.MockitoSugar
 import org.scalatest.{MustMatchers, FunSuite}
 
+import scala.util.Random
+
 class StreamChunkerTest extends FunSuite with MustMatchers with MockitoSugar {
 
   // give input & buffer size in MB
-  private def getChunker(inputSize: Int, bufferSize: Int): StreamChunker = {
-    val bais = new ByteArrayInputStream(new Array[Byte](inMB(inputSize)))
-    new StreamChunker(bais, inMB(bufferSize))
+  private def getChunker(inputSize: Int, bufferSize: Int): (StreamChunker, Array[Byte]) = {
+    val inputBytes = new Array[Byte](inputSize)
+    Random.nextBytes(inputBytes)
+    val inStream = new SingleByteStream(inputBytes)
+    (new StreamChunker(inStream, bufferSize), inputBytes)
   }
 
   private def countChunks(sc: StreamChunker): Int = {
     sc.foldLeft (0) ((sum, _) => sum + 1)
   }
 
-  private def inMB(num: Int): Int = {
-    num * 1024 * 1024
-  }
-
   test("Returns divided input streams") {
-    assert(countChunks(getChunker(21, 8)) == 3)
+    val (sc, _) = getChunker(21, 8)
+    assert(countChunks(sc) == 3)
   }
 
   test("an input stream smaller than buffer size results in single input stream the same size as original input") {
-    val sc = getChunker(3,8)
+    val (sc, _) = getChunker(3,8)
     val count = sc.chunks.foldLeft(0) { (count, chunk) =>
       assert(chunk.partNumber == 1)
-      assert(chunk.size == inMB(3))
+      assert(chunk.size == 3)
       count + 1
     }
     assert(count == 1)
   }
 
   test("each chunked output stream is the same size as the buffer setting, when possible") {
-    val sc = getChunker(8,2)
-    sc.chunks.foreach { chunk => assert(chunk.size == inMB(2)) }
+    val (sc, _) = getChunker(8,2)
+    sc.chunks.foreach { chunk => assert(chunk.size == 2) }
   }
 
   test("size field returned is accurate for the contents of the matching inputStream") {
-    val sc = getChunker(4,2)
+    val (sc, _) = getChunker(4,2)
     sc.chunks.foreach { chunk =>
       // don't do this at home, kids
       val ba = Stream.continually(chunk.inputStream.read).takeWhile(_ != -1).map(_.toByte).toArray
-      assert(ba.length == inMB(2))
+      assert(ba.length == 2)
     }
   }
 
   test("input stream chunks combine to form the same original input data") {
-    val input = "Ordering test for a string chunked into input streams"
-    val inBytes = input.getBytes
-    val bais = new ByteArrayInputStream(inBytes)
-    val sc = new StreamChunker(bais, inBytes.length)
+    val (sc, inputBytes) = getChunker(20, 6)
 
     val outBytes = sc.chunks.foldLeft(new Array[Byte](0)) { (outBytes, chunk) =>
       outBytes ++ Stream.continually(chunk.inputStream.read).takeWhile(_ != -1).map(_.toByte)
     }
-    val output = new String(outBytes)
-    assert(output == input)
+    assert(outBytes.sameElements(inputBytes))
   }
+
+  class SingleByteStream(val bytes: Array[Byte]) extends ByteArrayInputStream(bytes) {
+    override def read(output: Array[Byte], offset: Int, len: Int): Int = {
+      val byte = this.read()
+      if (byte == -1) {
+        byte
+      } else {
+        output(offset) = byte.toByte
+        1
+      }
+    }
+  }
+
 }

--- a/src/test/scala/com/socrata/snapshotter/StreamChunkerTest.scala
+++ b/src/test/scala/com/socrata/snapshotter/StreamChunkerTest.scala
@@ -1,0 +1,64 @@
+package com.socrata.snapshotter
+
+import java.io.{ByteArrayOutputStream, ByteArrayInputStream}
+
+import org.scalatest.mock.MockitoSugar
+import org.scalatest.{MustMatchers, FunSuite}
+
+class StreamChunkerTest extends FunSuite with MustMatchers with MockitoSugar {
+
+  // give input & buffer size in MB
+  private def getChunker(inputSize: Int, bufferSize: Int): StreamChunker = {
+    val bais = new ByteArrayInputStream(new Array[Byte](inMB(inputSize)))
+    new StreamChunker(bais, inMB(bufferSize))
+  }
+
+  private def countChunks(sc: StreamChunker): Int = {
+    sc.foldLeft (0) ((sum, _) => sum + 1)
+  }
+
+  private def inMB(num: Int): Int = {
+    num * 1024 * 1024
+  }
+
+  test("Returns divided input streams") {
+    assert(countChunks(getChunker(21, 8)) == 3)
+  }
+
+  test("an input stream smaller than buffer size results in single input stream the same size as original input") {
+    val sc = getChunker(3,8)
+    val count = sc.chunks.foldLeft(0) { (count, chunk) =>
+      assert(chunk.partNumber == 1)
+      assert(chunk.size == inMB(3))
+      count + 1
+    }
+    assert(count == 1)
+  }
+
+  test("each chunked output stream is the same size as the buffer setting, when possible") {
+    val sc = getChunker(8,2)
+    sc.chunks.foreach { chunk => assert(chunk.size == inMB(2)) }
+  }
+
+  test("size field returned is accurate for the contents of the matching inputStream") {
+    val sc = getChunker(4,2)
+    sc.chunks.foreach { chunk =>
+      // don't do this at home, kids
+      val ba = Stream.continually(chunk.inputStream.read).takeWhile(_ != -1).map(_.toByte).toArray
+      assert(ba.length == inMB(2))
+    }
+  }
+
+  test("input stream chunks combine to form the same original input data") {
+    val input = "Ordering test for a string chunked into input streams"
+    val inBytes = input.getBytes
+    val bais = new ByteArrayInputStream(inBytes)
+    val sc = new StreamChunker(bais, inBytes.length)
+
+    val outBytes = sc.chunks.foldLeft(new Array[Byte](0)) { (outBytes, chunk) =>
+      outBytes ++ Stream.continually(chunk.inputStream.read).takeWhile(_ != -1).map(_.toByte)
+    }
+    val output = new String(outBytes)
+    assert(output == input)
+  }
+}


### PR DESCRIPTION
Moves the logic that loops reading from input stream from gzipCompressInputStream into StreamChunker

The loop still reads to a guaranteed size (unless finished reading), but does so in blocks larger than 1 byte.