### PR TITLE
En 172

### DIFF
--- a/src/main/scala/com/socrata/snapshotter/BlobStoreManager.scala
+++ b/src/main/scala/com/socrata/snapshotter/BlobStoreManager.scala
@@ -151,6 +151,7 @@ class BlobStoreManager(bucketName: String, uploadPartSize: Int) extends Closeabl
   }
 
   object ParseKey {
+    // Our filenames are "resourcename:timestamp"; ":" is not a legal character in resource names
     val Pattern = """(.*):(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.?\d*Z)\.csv\.gz""".r
     def unapply(summary: S3ObjectSummary): Option[(String, Long, ResourceName, String)] =
       summary.getKey match {

--- a/src/main/scala/com/socrata/snapshotter/BlobStoreManager.scala
+++ b/src/main/scala/com/socrata/snapshotter/BlobStoreManager.scala
@@ -138,7 +138,7 @@ class BlobStoreManager(bucketName: String, uploadPartSize: Int) extends Closeabl
       objectSummaries.collect {
         case ParseKey(key, size, datasetId, timestamp) =>
           logger.debug(s"Found key: ${key}")
-          json"""{ datasetId: ${datasetId},
+          json"""{ datasetId: ${datasetId.underlying},
                    date:      ${timestamp},
                    size:      ${size} }"""
       }
@@ -151,11 +151,11 @@ class BlobStoreManager(bucketName: String, uploadPartSize: Int) extends Closeabl
   }
 
   object ParseKey {
-    val Pattern = """(....-....)-(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.?\d*Z)\.csv\.gz""".r
-    def unapply(summary: S3ObjectSummary): Option[(String, Long, String, String)] =
+    val Pattern = """(.*):(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.?\d*Z)\.csv\.gz""".r
+    def unapply(summary: S3ObjectSummary): Option[(String, Long, ResourceName, String)] =
       summary.getKey match {
         case Pattern(datasetId, timestamp) =>
-          Some((summary.getKey, summary.getSize, datasetId, timestamp))
+          Some((summary.getKey, summary.getSize, ResourceName(datasetId), timestamp))
         case _ =>
           None
       }

--- a/src/main/scala/com/socrata/snapshotter/ListService.scala
+++ b/src/main/scala/com/socrata/snapshotter/ListService.scala
@@ -12,20 +12,20 @@ import org.slf4j.LoggerFactory
 class ListService(blobStoreManager: BlobStoreManager) extends SimpleResource {
   private val logger = LoggerFactory.getLogger(getClass)
 
-  def service(datasetId: DatasetId, timestampPrefix: TimestampPrefix): HttpService = {
+  def service(resourceName: ResourceName, timestampPrefix: TimestampPrefix): HttpService = {
     new SimpleResource {
       override def get: HttpService = req =>
-        handleRequest(req, datasetId, timestampPrefix)
+        handleRequest(req, resourceName, timestampPrefix)
     }
   }
 
-  def handleRequest(req: HttpRequest, datasetId: DatasetId, prefix: TimestampPrefix): HttpResponse = {
-    val resp = requestList(datasetId, prefix)
-    OK ~> Content("application/json", s"$resp" )
+  def handleRequest(req: HttpRequest, resourceName: ResourceName, prefix: TimestampPrefix): HttpResponse = {
+    val resp = requestList(resourceName, prefix)
+    OK ~> Json(resp)
   }
 
-  def requestList(datasetId: DatasetId, prefix: TimestampPrefix): JValue = {
-    blobStoreManager.listObjects(datasetId.uid + "-" + prefix.prefix)
+  def requestList(resourceName: ResourceName, prefix: TimestampPrefix): JValue = {
+    blobStoreManager.listObjects(resourceName.underlying + ":" + prefix.prefix)
   }
 
 }

--- a/src/main/scala/com/socrata/snapshotter/SnapshotDAO.scala
+++ b/src/main/scala/com/socrata/snapshotter/SnapshotDAO.scala
@@ -1,9 +1,19 @@
 package com.socrata.snapshotter
 
+import java.io.InputStream
+
+import com.rojoma.simplearm.v2.ResourceScope
+import org.joda.time.DateTime
+
 import scala.collection.immutable.SortedSet
 
 trait SnapshotDAO {
   def datasetsWithSnapshots(): Set[String]
   def datasetSnapshots(dataset: String): SortedSet[Long]
+  def exportSnapshot[T](dataset: String, snapshot: Long)(f: Option[SnapshotDAO.SnapshotInfo] => T): T
   def deleteSnapshot(dataset: String, snapshot: Long): Unit
+}
+
+object SnapshotDAO {
+  case class SnapshotInfo(lastModified: DateTime, data: InputStream)
 }

--- a/src/main/scala/com/socrata/snapshotter/SnapshotDAO.scala
+++ b/src/main/scala/com/socrata/snapshotter/SnapshotDAO.scala
@@ -8,10 +8,10 @@ import org.joda.time.DateTime
 import scala.collection.immutable.SortedSet
 
 trait SnapshotDAO {
-  def datasetsWithSnapshots(): Set[String]
-  def datasetSnapshots(dataset: String): SortedSet[Long]
-  def exportSnapshot[T](dataset: String, snapshot: Long)(f: Option[SnapshotDAO.SnapshotInfo] => T): T
-  def deleteSnapshot(dataset: String, snapshot: Long): Unit
+  def datasetsWithSnapshots(): Set[ResourceName]
+  def datasetSnapshots(dataset: ResourceName): SortedSet[Long]
+  def exportSnapshot[T](dataset: ResourceName, snapshot: Long)(f: Option[SnapshotDAO.SnapshotInfo] => T): T
+  def deleteSnapshot(dataset: ResourceName, snapshot: Long): Unit
 }
 
 object SnapshotDAO {

--- a/src/main/scala/com/socrata/snapshotter/SnapshotService.scala
+++ b/src/main/scala/com/socrata/snapshotter/SnapshotService.scala
@@ -27,9 +27,10 @@ case class SnapshotService(sfClient: CuratedServiceClient, blobStoreManager: Blo
   private val logger = LoggerFactory.getLogger(getClass)
 
   def handleSnapshotRequest(req: HttpRequest, resourceName: ResourceName): HttpResponse = {
+    val phase = req.queryParameter("stage").getOrElse("latest")
     val makeReq: RequestBuilder => SimpleHttpRequest = { base =>
       val csvReq = base.
-        addPaths(Seq("export", resourceName.underlying + ".csv")).
+        addPaths(Seq("export", resourceName.underlying, phase + ".csv")).
         addHeader(RequestId.ReqIdHeader -> req.requestId).
         get
       logger.debug(csvReq.toString())

--- a/src/main/scala/com/socrata/snapshotter/SnapshotterConfig.scala
+++ b/src/main/scala/com/socrata/snapshotter/SnapshotterConfig.scala
@@ -10,7 +10,6 @@ class SnapshotterServiceConfig(config: Config) extends ConfigClass(config, "com.
 
   val curator = getConfig("curator", new CuratorConfig(_, _))
   val advertisement = getConfig("advertisement", new DiscoveryConfig(_, _))
-  val core = getConfig("core", new CuratedClientConfig(_, _))
   val sodaFountain = getConfig("soda-fountain", new CuratedClientConfig(_, _))
 }
 

--- a/src/main/scala/com/socrata/snapshotter/SodaWatcher.scala
+++ b/src/main/scala/com/socrata/snapshotter/SodaWatcher.scala
@@ -2,15 +2,23 @@ package com.socrata.snapshotter
 
 import java.io.{IOException, Closeable}
 
+import com.rojoma.simplearm.v2._
+import org.joda.time.DateTime
+
 import scala.concurrent.duration.FiniteDuration
 import org.apache.curator.framework.CuratorFramework
 import org.apache.curator.framework.recipes.leader.LeaderLatch
 import org.slf4j.LoggerFactory
 
+import scala.util.control.Breaks
+
 class SodaWatcher(curatorFramework: CuratorFramework,
                   latchPath: String,
                   pause: FiniteDuration,
-                  snapshotDAO: SnapshotDAO) extends Closeable {
+                  snapshotDAO: SnapshotDAO,
+                  gzipBufferSize: Int,
+                  blobStoreManager: BlobStoreManager,
+                  basenameFor: (DatasetId, DateTime) => String) extends Closeable {
   private val log = LoggerFactory.getLogger(classOf[SodaWatcher])
   private val latch = new LeaderLatch(curatorFramework, latchPath)
   private val pauseMS = pause.toMillis
@@ -48,6 +56,9 @@ class SodaWatcher(curatorFramework: CuratorFramework,
       }
     }
 
+    private def datasetIdOfSFResourceName(s: String): DatasetId =
+      DatasetId(s.drop(1))
+
     private def poll(): Unit = {
       while(true) {
         Thread.sleep(pauseMS)
@@ -55,14 +66,38 @@ class SodaWatcher(curatorFramework: CuratorFramework,
         for(ds <- snapshotDAO.datasetsWithSnapshots().par) {
           if(!latch.hasLeadership) { return }
           try {
-            for(snapshot <- snapshotDAO.datasetSnapshots(ds)) {
-              if(!latch.hasLeadership) { return }
-              log.info("Purging snapshot {} on dataset {}", snapshot, ds)
-              snapshotDAO.deleteSnapshot(ds, snapshot)
+            val b = new Breaks
+            import b._
+            breakable {
+              for(snapshot <- snapshotDAO.datasetSnapshots(ds)) {
+                if(!latch.hasLeadership) { return }
+                log.info("Exporting snapshot {} on dataset {}", snapshot, ds)
+                val datasetId = datasetIdOfSFResourceName(ds)
+                snapshotDAO.exportSnapshot(ds, snapshot) {
+                  case Some(SnapshotDAO.SnapshotInfo(lastModified, stream)) =>
+                    val basename = basenameFor(datasetId, lastModified)
+                    val result =
+                      using(new GZipCompressInputStream(stream, gzipBufferSize)) { inStream =>
+                        blobStoreManager.multipartUpload(inStream, s"$basename.csv.gz")
+                      }
+                    if(result.isRight) {
+                      stream.close()
+                      log.info("Purging snapshot {} on dataset {}", snapshot, ds)
+                      snapshotDAO.deleteSnapshot(ds, snapshot)
+                    } else {
+                      log.warn("Problem uploading snapshot {} on dataset {} to amazon; not deleting it")
+                      // the blobstore will have already logged the actual problem.
+                      // abort processing this dataset
+                      break()
+                    }
+                  case None =>
+                    log.info("Reported snapshot missing; ignoring it (maybe we lost leadership?)")
+                }
+              }
             }
           } catch {
             case e: IOException =>
-              log.warn("Error purging snapshot on dataset {}; ignoring", ds : Any, e)
+              log.warn("Error snapshotting dataset {}; ignoring", ds : Any, e)
           }
         }
       }

--- a/src/main/scala/com/socrata/snapshotter/SodaWatcher.scala
+++ b/src/main/scala/com/socrata/snapshotter/SodaWatcher.scala
@@ -81,7 +81,7 @@ class SodaWatcher(curatorFramework: CuratorFramework,
                       log.info("Purging snapshot {} on dataset {}", snapshot, resourceName.underlying)
                       snapshotDAO.deleteSnapshot(resourceName, snapshot)
                     } else {
-                      log.warn("Problem uploading snapshot {} on dataset {} to amazon; not deleting it")
+                      log.warn("Problem uploading snapshot {} on dataset {} to the blobstore; not deleting it")
                       // the blobstore will have already logged the actual problem.
                       // abort processing this dataset
                       break()


### PR DESCRIPTION
Mostly using SF resource names instead of dataset IDs.  We'll let core be the one to do that mapping; snapshotter is now an internal service.